### PR TITLE
`tfprovider.Provider` adds a new method `ImportManagedResourceState`

### DIFF
--- a/tfprovider/common.go
+++ b/tfprovider/common.go
@@ -34,6 +34,8 @@ type ManagedResourceType = common.ManagedResourceType
 
 type DataResourceType = common.DataResourceType
 
+type ImportedResource = common.ImportedResource
+
 type ManagedResourceReadRequest = common.ManagedResourceReadRequest
 
 type ManagedResourceReadResponse = common.ManagedResourceReadResponse

--- a/tfprovider/internal/common/resource_types.go
+++ b/tfprovider/internal/common/resource_types.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"context"
+
+	"github.com/zclconf/go-cty/cty"
 )
 
 // ManagedResourceType represents a managed resource type belonging to a
@@ -35,4 +37,20 @@ type DataResourceType interface {
 	// to allow the interface to expand in future to support new provider
 	// plugin protocol features.
 	Sealed() Sealed
+}
+
+// ImportedResource represents an object being imported.
+type ImportedResource struct {
+	// TypeName is the name of the resource type associated with the
+	// returned state.
+	TypeName string
+
+	// State is the state of the remote object being imported. This may not be
+	// complete, but must contain enough information to uniquely identify the
+	// resource.
+	State cty.Value
+
+	// Private is an opaque blob that will be stored in state along with the
+	// resource. It is intended only for interpretation by the provider itself.
+	OpaquePrivate []byte
 }

--- a/tfprovider/internal/protocol5/provider.go
+++ b/tfprovider/internal/protocol5/provider.go
@@ -2,6 +2,7 @@ package protocol5
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/apparentlymart/terraform-provider/internal/tfplugin5"
@@ -33,10 +34,11 @@ func NewProvider(ctx context.Context, plugin *rpcplugin.Plugin, clientProxy inte
 	}
 
 	return &Provider{
-		client:     client,
-		plugin:     plugin,
-		schema:     schema,
-		configured: false,
+		client:       client,
+		plugin:       plugin,
+		schema:       schema,
+		configured:   false,
+		configuredMu: &sync.Mutex{},
 	}, nil
 }
 
@@ -148,6 +150,43 @@ func (p *Provider) ManagedResourceType(typeName string) common.ManagedResourceTy
 		typeName: typeName,
 		schema:   schema,
 	}
+}
+
+func (p *Provider) ImportManagedResourceState(ctx context.Context, typeName string, id string) ([]common.ImportedResource, common.Diagnostics) {
+	p.configuredMu.Lock()
+	if !p.configured {
+		return nil, nil
+	}
+	p.configuredMu.Unlock()
+
+	var diags common.Diagnostics
+	resp, err := p.client.ImportResourceState(ctx, &tfplugin5.ImportResourceState_Request{
+		TypeName: typeName,
+		Id:       id,
+	})
+	diags = append(diags, common.RPCErrorDiagnostics(err)...)
+	if err != nil {
+		return nil, diags
+	}
+	diags = append(diags, decodeDiagnostics(resp.Diagnostics)...)
+
+	var resources []common.ImportedResource
+	for _, raw := range resp.ImportedResources {
+		resource := common.ImportedResource{
+			TypeName:      raw.TypeName,
+			OpaquePrivate: raw.Private,
+		}
+		schema, ok := p.schema.ManagedResourceTypes[raw.TypeName]
+		if !ok {
+			diags = append(diags, common.RPCErrorDiagnostics(fmt.Errorf("unknown resource type %q", raw.TypeName))...)
+			continue
+		}
+		state, moreDiags := decodeDynamicValue(raw.State, schema.Content)
+		resource.State = state
+		diags = append(diags, moreDiags...)
+		resources = append(resources, resource)
+	}
+	return resources, diags
 }
 
 func (p *Provider) Close() error {

--- a/tfprovider/internal/protocol5/schema.go
+++ b/tfprovider/internal/protocol5/schema.go
@@ -124,7 +124,7 @@ func decodeDynamicValue(raw *tfplugin5.DynamicValue, schema *tfschema.Block) (ct
 		}
 		return val, nil
 	case len(raw.Msgpack) > 0:
-		val, err := ctymsgpack.Unmarshal(raw.Json, ty)
+		val, err := ctymsgpack.Unmarshal(raw.Msgpack, ty)
 		if err != nil {
 			return cty.DynamicVal, common.ErrorDiagnostics(
 				"Provider returned invalid object",

--- a/tfprovider/internal/protocol6/schema.go
+++ b/tfprovider/internal/protocol6/schema.go
@@ -124,7 +124,7 @@ func decodeDynamicValue(raw *tfplugin6.DynamicValue, schema *tfschema.Block) (ct
 		}
 		return val, nil
 	case len(raw.Msgpack) > 0:
-		val, err := ctymsgpack.Unmarshal(raw.Json, ty)
+		val, err := ctymsgpack.Unmarshal(raw.Msgpack, ty)
 		if err != nil {
 			return cty.DynamicVal, common.ErrorDiagnostics(
 				"Provider returned invalid object",

--- a/tfprovider/tfprovider.go
+++ b/tfprovider/tfprovider.go
@@ -58,6 +58,11 @@ type Provider interface {
 	// method. An unconfigured provider always returns nil.
 	ManagedResourceType(name string) ManagedResourceType
 
+	// ImportManagedResourceState requests that the given resource be imported.
+	// It's possible for providers to import multiple related types with a single
+	// import request.
+	ImportManagedResourceState(ctx context.Context, typeName string, id string) ([]ImportedResource, Diagnostics)
+
 	// Close kills the child process for this provider plugin, rendering the
 	// reciever unusable. Any further calls on the object after Close returns
 	// cause undefined behavior.


### PR DESCRIPTION
Add a new method `ImportManagedResourceState` to `tfprovider.Provider` and implement it for both `protocol5.Provider` and `protocol6.Provider`.

Meanwhile, this commit fixes two bugs in existing code:
- `protocol5.Provider` and `protocol6.Provider` doesn't initialize the `configureMu` in their `NewProvider` method
- `decodeDynamicValue` in `protocol5` and `protocol6` packages incorrectly unmarshal the json payload when it actually should unmarshal msgpack